### PR TITLE
generic interaction analytics

### DIFF
--- a/02-analytics/technical.md
+++ b/02-analytics/technical.md
@@ -549,3 +549,19 @@ Collected when a game is closed for any reason.
 |--------------------|-----------------------------|--------------------------|
 | Game ID            | gameId                      | per-game stats           |
 | Time spent         | timeSpent                   | seconds. measure usage    |
+
+
+
+## Interaction event (interaction)
+
+Generic interaction events, e.g. button clicks that doesnt need its own table
+
+### Data
+
+| Data               | Name                        | Commnets                 |
+|--------------------|-----------------------------|--------------------------|
+| Interaction        | interaction                 | 'play', 'pause', 'share', 'like', 'mute', etc.  |
+| Page code            | pageCode                   |  static ('shorts', 'episode') or dynamic ('kids-frontpage2', etc.)    |
+| Context Element Id           | contextElementId      |  ID of e.g. the episode or short this was performed on.   |
+| Context Element Type         | contextElementType    | type for the ID above, e.g. 'episode', 'shorts', 'show', etc.    |
+

--- a/02-analytics/technical.md
+++ b/02-analytics/technical.md
@@ -563,5 +563,5 @@ Generic interaction events, e.g. button clicks that doesnt need its own table
 | Interaction        | interaction                 | 'play', 'pause', 'share', 'like', 'mute', etc.  |
 | Page code            | pageCode                   |  static ('shorts', 'episode') or dynamic ('kids-frontpage2', etc.)    |
 | Context Element Id           | contextElementId      |  ID of e.g. the episode or short this was performed on.   |
-| Context Element Type         | contextElementType    | type for the ID above, e.g. 'episode', 'shorts', 'show', etc.    |
+| Context Element Type         | contextElementType    | type for the ID above, e.g. 'episode', 'short', 'show', etc.    |
 


### PR DESCRIPTION
I think we should have a generic table for this because it allows me to quickly throw in a bunch of this stuff everywhere without having to think about table naming, column naming, etc.

But we keep what we already have, e.g. content_shared etc.